### PR TITLE
Remove ignored files from ffetch stash

### DIFF
--- a/git-ffetch
+++ b/git-ffetch
@@ -5,8 +5,8 @@
 # Fetch all git remotes
 git fetch --all
 
-# Backup uncommitted changes, including index, untracked files and ignored ones
-git stash save --all "WIP before FFETCH calling"
+# Backup uncommitted changes, including index and untracked files. It does not backup ignored files.
+git stash save --include-untracked "WIP before FFETCH calling"
 
 # Checkout a new (or not) temporal branch
 git checkout -B __FFETCH_AUX


### PR DESCRIPTION
Hi @gastonmancini, @matiasbeckerle and @jfazzini

@Gkolocsar has detected an issue with stashing ignored files:

``` console
$ git ffetch
Fetching origin
Fetching upstream
...
error: open("D_Data/D_Data.dbmdl"): Permission denied
fatal: Unable to process path D_Data/D_Data.dbmdl
Cannot save the untracked files
M       Application/Alerts/AlertService.cs
Switched to a new branch '__FFETCH_AUX'
...
Deleted branch __FFETCH_AUX (was 6befcda).
No stash found.
```

So, maybe the best option is to _ignore ignored files_. Do you agree?
