### PR TITLE
Allow to fetch a TFS branch independently

### DIFF
--- a/git-f-develop
+++ b/git-f-develop
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Workaround for git-tfs bug
+## see https://github.com/git-tfs/git-tfs/issues/576
+
+git tfsfetch develop default

--- a/git-f-dspmigration
+++ b/git-f-dspmigration
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Workaround for git-tfs bug
+## see https://github.com/git-tfs/git-tfs/issues/576
+
+git tfsfetch dspmigration dspmigration

--- a/git-f-integration
+++ b/git-f-integration
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Workaround for git-tfs bug
+## see https://github.com/git-tfs/git-tfs/issues/576
+
+git tfsfetch integration integration

--- a/git-f-qa
+++ b/git-f-qa
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Workaround for git-tfs bug
+## see https://github.com/git-tfs/git-tfs/issues/576
+
+git tfsfetch qa qa

--- a/git-tfsfetch
+++ b/git-tfsfetch
@@ -1,0 +1,25 @@
+#!/bin/sh
+## Workaround for git-tfs bug
+## see https://github.com/git-tfs/git-tfs/issues/576
+## $1 = upstream branch
+## $2 = git-tfs remote
+
+# Fetch all git remotes
+git fetch upstream $1
+
+# Backup uncommitted changes, including index and untracked files. It does not backup ignored files.
+git stash save --include-untracked "WIP before tfsfetch calling"
+
+# Checkout a new (or not) temporal branch
+git checkout -B __FFETCH_AUX
+
+# Reset to upstream/$1 and fetch tfs/$2
+git reset --hard upstream/$1
+git tfs fetch -i $2
+
+# Restore the previous branch and delete temporal one
+git checkout -
+git branch -D __FFETCH_AUX
+
+# Restore uncommitted backed files
+git stash pop


### PR DESCRIPTION
Hi @MakingSense/dataonix,

The idea of this change is to make our TFS fetch more quick and also mitigate issues related with switch branches or duplicated commits.

The idea is allow to fetch only one branch, from GitHub and TFS, 
- Trunk / develop: `$ git f-develop`
- Integration / integration: `$ git f-integration`
- QA / qa: `$ git f-qa`
- dspmigration / dspmigration: `$ git f-dspmigration`

if you think that it is useful, I will merge it and you have to pull the last commit from `migration` branch on `MakingSense/git-helpers` repo.
