### PR TITLE
Remove QA fetching because is git-tfs synchronization is broken

### DIFF
--- a/git-mfetch
+++ b/git-mfetch
@@ -13,9 +13,10 @@ git stash save --include-untracked "WIP before MFETCH calling"
 # Checkout a new (or not) temporal branch
 git checkout -B __MFETCH_AUX
 
+## Removed QA fetching because is git-tfs synchronization is broken
 # Reset to upstream/qa and fetch tfs/qa
-git reset --hard upstream/qa
-git tfs fetch -i qa
+# git reset --hard upstream/qa
+# git tfs fetch -i qa
 
 # Reset to upstream/develop and fetch tfs/default
 git reset --hard upstream/develop


### PR DESCRIPTION
HI @MakingSense/dataonix, sadly our git-tfs synchronization between TFS `QA` branch and Git `qa` branch was broken because TFS branch renaming and the creation of a new branch with the same name, an scenario that git-tfs cannot deal with.

For that reason, it is not necessary anymore to fetch TFS `QA` branch. `QA` to `DEV` merges should be done with TFS and we need to consider Git `QA` branch as broken.
